### PR TITLE
Add flushBuffer to avoid an empty response

### DIFF
--- a/src/main/java/com/googlecode/webutilities/filters/ClosureCompilerFilter.java
+++ b/src/main/java/com/googlecode/webutilities/filters/ClosureCompilerFilter.java
@@ -91,6 +91,8 @@ public class ClosureCompilerFilter extends AbstractFilter {
 
             chain.doFilter(req, wrapper);
 
+            wrapper.flushBuffer();
+
             Writer out = resp.getWriter();
             String mime = wrapper.getContentType();
             if (!isMIMEAccepted(mime)) {


### PR DESCRIPTION
In some cases the response is empty, flushing the buffer resolves this. This solves a similar issue (with the same solution) as: https://code.google.com/archive/p/webutilities/issues/60