### PR TITLE
Thread safe use of Closure CompilerOptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.google.javascript</groupId>
             <artifactId>closure-compiler</artifactId>
-            <version>v20140407</version>
+            <version>v20160517</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
CompilerOptions is not thread safe and not intended to be reused, so I moved to be constructed in onFilter instead of the init method. Also took the opportunity to update to the latest version of Closure (acceptConstKeyword is not a compiler option anymore, so that's removed).