### PR TITLE
Several concurrency and memory improvements

### DIFF
--- a/src/main/java/com/googlecode/webutilities/common/Constants.java
+++ b/src/main/java/com/googlecode/webutilities/common/Constants.java
@@ -18,6 +18,7 @@ package com.googlecode.webutilities.common;
 
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.LongStream;
 
@@ -124,7 +125,7 @@ public final class Constants {
     public static final Pattern CSS_IMG_URL_PATTERN = Pattern.compile("[uU][rR][lL]\\s*\\(\\s*['\"]?([^('|\")]*)['\"]?\\s*\\)");
 
     //Map that holds Image path -> CSS files path that refers it
-    public static final Map<String, List<String>> CSS_IMG_REFERENCES = new HashMap<>();
+    public static final Map<String, List<String>> CSS_IMG_REFERENCES = new ConcurrentHashMap<>();
 
     private Constants() {
     } //non instantiable

--- a/src/main/java/com/googlecode/webutilities/filters/compression/CompressedServletOutputStream.java
+++ b/src/main/java/com/googlecode/webutilities/filters/compression/CompressedServletOutputStream.java
@@ -152,6 +152,9 @@ public class CompressedServletOutputStream extends ServletOutputStream {
                 flushBufferToStream(outputStream);
                 outputStream.flush();
                 compressed.finish();
+                // explicitly close compressed, which causes the Deflater used to free its memory!
+                //  see: http://www.devguli.com/blog/eng/java-deflater-and-outofmemoryerror/
+                compressed.getCompressedOutputStream().close();
                 outputStream.close();
             }
 

--- a/src/main/java/com/googlecode/webutilities/util/Utils.java
+++ b/src/main/java/com/googlecode/webutilities/util/Utils.java
@@ -358,9 +358,8 @@ public final class Utils {
         if (realPath.endsWith(EXT_CSS)) { // check if any image references by this css has been modified or not
             long cssLastModified = realFile.lastModified();
 
-            List<String> referencedImages = CSS_IMG_REFERENCES.get(realPath);
-
-            if (referencedImages != null) {
+            final List<String> referencedImages = new ArrayList<>(CSS_IMG_REFERENCES.getOrDefault(realPath,Collections.emptyList()));
+            if (!referencedImages.isEmpty()) {
                 for (String referenceImage : referencedImages) {
                     File imgFile = new File(referenceImage);
                     if (imgFile.isFile() && imgFile.exists()) {

--- a/src/test/java/com/googlecode/webutilities/test/util/UtilsTest.java
+++ b/src/test/java/com/googlecode/webutilities/test/util/UtilsTest.java
@@ -1,0 +1,97 @@
+package com.googlecode.webutilities.test.util;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.googlecode.webutilities.util.Utils;
+import com.mockrunner.mock.web.MockServletContext;
+import com.mockrunner.mock.web.WebMockObjectFactory;
+
+public class UtilsTest {
+	
+	 
+
+	private static boolean start = true;
+	
+	private static File cssFile;
+	private static String cssPath;
+	
+	
+	@BeforeClass
+	public static void init() throws IOException {
+		cssFile = File.createTempFile("webutilities", ".css"); 
+		FileWriter writer;
+		writer = new FileWriter(cssFile);
+		writer.write(".div { display:none;}");
+		writer.close();
+		cssPath = UtilsTest.class.getResource("/resources/css/a.css").getPath();
+	}
+	
+	
+	@Before
+	public void createUpdater() {
+		// create a single thread which updates the reference map with 'new images' every millisecond
+		Executors.newSingleThreadExecutor().submit(new Runnable() {
+			
+			@Override
+			public void run() {
+				while(start) {
+					try {
+						// keep adding new empty img files to the css reference
+						File imgFile = File.createTempFile("temp", ".img");
+						Utils.updateReferenceMap(cssPath, imgFile.getAbsolutePath());
+					} catch (IOException e1) {
+						System.err.println(e1);
+					}
+					
+					try {
+						TimeUnit.MILLISECONDS.sleep(1);
+					} catch (InterruptedException e) {
+						return;
+					}
+				}				
+			}
+		
+		});
+		
+	}
+	
+	@Test
+	public void testConcurreny() {
+		try {
+			// setup
+			WebMockObjectFactory factory = new WebMockObjectFactory();
+			
+			final List<String> resourcesToMerge = new ArrayList<String>();
+			resourcesToMerge.add("css/a.css");
+			
+			MockServletContext context = factory.createMockServletContext();
+			context.setRealPath("css/a.css", cssPath);
+			
+			for (int i=0;i<20;i++) {
+				final String result  = Utils.buildETagForResources(resourcesToMerge, context);
+				Assert.assertNotNull(result);
+			}
+		} catch (Exception e) {
+			
+			if (e instanceof ConcurrentModificationException ) {
+				Assert.fail("ConcurrentModificationException happend, which should not happen");
+			}
+			e.printStackTrace();
+			Assert.fail("Unexpected exception happend, which should not happen");
+		} finally {
+			start = false;
+		}
+	}
+}


### PR DESCRIPTION
Hi,

We have encountered a concurrency issue and a memory leak using this library under very high loads (600+) users during a load test.

The concurrency issue showed up as follows:

Root Cause:
java.util.ConcurrentModificationException
	at java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:966)
	at java.util.LinkedList$ListItr.next(LinkedList.java:888)
	at com.googlecode.webutilities.util.Utils.buildETagForResource(Utils.java:397)
	at com.googlecode.webutilities.util.Utils.buildETagForResources(Utils.java:340)

Info:een onbekende service
MDC Context:null

Full Stack:
java.util.ConcurrentModificationException
	at java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:966)
	at java.util.LinkedList$ListItr.next(LinkedList.java:888)
	at com.googlecode.webutilities.util.Utils.buildETagForResource(Utils.java:397)


Which i fixed by using a ConcurrentHashmap iso Hashmap.

Secondly,. we also encountered OOME like: 

Root Cause:
java.lang.OutOfMemoryError
	at java.util.zip.Deflater.init(Native Method)
	at java.util.zip.Deflater.<init>(Deflater.java:171)
	at java.util.zip.GZIPOutputStream.<init>(GZIPOutputStream.java:90)
	at java.util.zip.GZIPOutputStream.<init>(GZIPOutputStream.java:109)

Info:een onbekende service
MDC Context:{user=sorobot060, sessionid=65:1}

Full Stack:
java.lang.OutOfMemoryError
	at java.util.zip.Deflater.init(Native Method)
	at java.util.zip.Deflater.<init>(Deflater.java:171)
	at java.util.zip.GZIPOutputStream.<init>(GZIPOutputStream.java:90)
	at java.util.zip.GZIPOutputStream.<init>(GZIPOutputStream.java:109)
	at com.googlecode.webutilities.filters.compression.GZIPEncodedStreamsFactory$1.<init>(EncodedStreamsFactory.java:77)

This let me to the following site:  http://www.devguli.com/blog/eng/java-deflater-and-outofmemoryerror/    

And applying this fix by explicitly calling close on the compressedstream. 

Both fixed are in this request.

Thx!

